### PR TITLE
Fix module path from hooklift to enthus-golang

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ Go is unlike any other language in that it forces a specific development workflo
 * Make sure you run `go fmt` to format your code before submitting your pull request.
 
 ### Workflow for third-party code contributions
-* In Github, fork `https://github.com/hooklift/gowsdl` to your own account
-* Get the package using "go get": `go get github.com/hooklift/gowsdl`
-* Move to where the package was cloned: `cd $GOPATH/src/github.com/hooklift/gowsdl/`
+* In Github, fork `https://github.com/enthus-golang/gowsdl` to your own account
+* Get the package using "go get": `go get github.com/enthus-golang/gowsdl`
+* Move to where the package was cloned: `cd $GOPATH/src/github.com/enthus-golang/gowsdl/`
 * Add a git remote pointing to your own fork: `git remote add downstream git@github.com:<your_account>/gowsdl.git`
 * Create a branch for making your changes, then commit them.
 * Push changes to downstream repository, this is your own fork: `git push <mybranch> downstream`
@@ -48,7 +48,7 @@ Go is unlike any other language in that it forces a specific development workflo
 ### Workflow for core developers
 Since core developers usually have access to the upstream repository, there is no need for having a workflow like the one for thid-party contributors.
 
-* Get the package using "go get": `go get github.com/hooklift/gowsdl`
+* Get the package using "go get": `go get github.com/enthus-golang/gowsdl`
 * Create a branch for making your changes, then commit them.
 * Push changes to the repository: `git push origin <mybranch>`
 * In Github, create the Pull Request from your branch to master.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # WSDL to Go
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hooklift/gowsdl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![GoDoc](https://godoc.org/github.com/hooklift/gowsdl?status.svg)](https://godoc.org/github.com/hooklift/gowsdl)
-[![Build Status](https://github.com/hooklift/gowsdl/workflows/Test/badge.svg)](https://github.com/hooklift/gowsdl/actions)
+[![GoDoc](https://godoc.org/github.com/enthus-golang/gowsdl?status.svg)](https://godoc.org/github.com/enthus-golang/gowsdl)
+[![Build Status](https://github.com/enthus-golang/gowsdl/workflows/Test/badge.svg)](https://github.com/enthus-golang/gowsdl/actions)
 [![codecov](https://codecov.io/gh/hooklift/gowsdl/branch/main/graph/badge.svg)](https://codecov.io/gh/hooklift/gowsdl)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hooklift/gowsdl)](https://goreportcard.com/report/github.com/hooklift/gowsdl)
+[![Go Report Card](https://goreportcard.com/badge/github.com/enthus-golang/gowsdl)](https://goreportcard.com/report/github.com/enthus-golang/gowsdl)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
 Generates idiomatic Go code from WSDL files with support for WSDL 1.1, WSDL 2.0, and modern Go features including generics.
@@ -15,9 +15,9 @@ Generates idiomatic Go code from WSDL files with support for WSDL 1.1, WSDL 2.0,
 
 ### Install
 
-* [Download release](https://github.com/hooklift/gowsdl/releases)
+* [Download release](https://github.com/enthus-golang/gowsdl/releases)
 * Download and build locally
-    * Go 1.21+: `go install github.com/hooklift/gowsdl/cmd/gowsdl@latest`
+    * Go 1.21+: `go install github.com/enthus-golang/gowsdl/cmd/gowsdl@latest`
 * Install from Homebrew: `brew install gowsdl`
 
 ### Goals
@@ -164,7 +164,7 @@ When working with local WSDL files that reference external schemas:
 This implementation addresses all the features requested in [issue #10](https://github.com/enthus-golang/gowsdl/issues/10), including the original TODOs:
 
 - ✅ **Support for generating namespaces** (main.go:41) - Complete namespace management system
-- ✅ **Resolve XSD element references** (main.go:39) - Full element reference resolution  
+- ✅ **Resolve XSD element references** (main.go:39) - Full element reference resolution
 - ✅ **Local schema resolution** (main.go:37) - Enhanced local and remote schema handling
 - ✅ **WSDL 2.0 Support** - Complete parsing and code generation
 - ✅ **Better error messages** - Contextual errors with suggestions

--- a/cmd/gowsdl/main.go
+++ b/cmd/gowsdl/main.go
@@ -59,7 +59,7 @@ import (
 	"strings"
 	"time"
 
-	gen "github.com/hooklift/gowsdl"
+	gen "github.com/enthus-golang/gowsdl"
 )
 
 // Version is initialized in compilation time by go build.

--- a/compat.go
+++ b/compat.go
@@ -8,10 +8,10 @@ import (
 	"crypto/tls"
 	"time"
 
-	"github.com/hooklift/gowsdl/pkg/core"
-	"github.com/hooklift/gowsdl/pkg/http"
-	"github.com/hooklift/gowsdl/pkg/parser"
-	"github.com/hooklift/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/core"
+	"github.com/enthus-golang/gowsdl/pkg/http"
+	"github.com/enthus-golang/gowsdl/pkg/parser"
+	"github.com/enthus-golang/gowsdl/pkg/types"
 )
 
 // Re-export types for backward compatibility

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -66,7 +66,7 @@ Common validation errors:
 Use `errors.As` to check for specific error types:
 
 ```go
-import "github.com/hooklift/gowsdl"
+import "github.com/enthus-golang/gowsdl"
 
 g, err := gowsdl.NewGoWSDL(wsdlPath, "myservice", false, true)
 if err != nil {

--- a/example/example.go
+++ b/example/example.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hooklift/gowsdl/example/gen"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/example/gen"
+	"github.com/enthus-golang/gowsdl/soap"
 )
 
 func ExampleBasicUsage() {

--- a/example/gen/gen.go
+++ b/example/gen/gen.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"time"
 
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 )
 
 // against "unused imports"

--- a/example/server/example.go
+++ b/example/server/example.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hooklift/gowsdl/example/server/gen"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/example/server/gen"
+	"github.com/enthus-golang/gowsdl/soap"
 )
 
 var done = make(chan struct{})

--- a/example/server/gen/myservice.go
+++ b/example/server/gen/myservice.go
@@ -5,7 +5,7 @@ package gen
 import (
 	"context"
 	"encoding/xml"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 	"time"
 )
 

--- a/fixtures/epcis/epcisquery.src
+++ b/fixtures/epcis/epcisquery.src
@@ -5,7 +5,7 @@ package myservice
 import (
 	"context"
 	"encoding/xml"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 	"time"
 )
 

--- a/fixtures/epcis/epcisquery_gen.src
+++ b/fixtures/epcis/epcisquery_gen.src
@@ -5,7 +5,7 @@ package myservice
 import (
 	"context"
 	"encoding/xml"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 	"time"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hooklift/gowsdl
+module github.com/enthus-golang/gowsdl
 
 go 1.21
 

--- a/gowsdl_facade.go
+++ b/gowsdl_facade.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/hooklift/gowsdl/pkg/generator"
-	"github.com/hooklift/gowsdl/pkg/utils"
+	"github.com/enthus-golang/gowsdl/pkg/generator"
+	"github.com/enthus-golang/gowsdl/pkg/utils"
 )
 
 // GoWSDL is the main facade for WSDL code generation

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hooklift/gowsdl/pkg/generator"
+	"github.com/enthus-golang/gowsdl/pkg/generator"
 )
 
 func TestElementGenerationDoesntCommentOutStructProperty(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -71,8 +71,8 @@ func TestIntegrationRealWSDLFiles(t *testing.T) {
 
 go 1.21
 
-require github.com/hooklift/gowsdl v0.0.0
-replace github.com/hooklift/gowsdl => ` + getRootDir()
+require github.com/enthus-golang/gowsdl v0.0.0
+replace github.com/enthus-golang/gowsdl => ` + getRootDir()
 
 			err = os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goModContent), 0644)
 			require.NoError(t, err)
@@ -210,10 +210,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/hooklift/gowsdl v0.0.0
+	github.com/enthus-golang/gowsdl v0.0.0
 )
 
-replace github.com/hooklift/gowsdl => ` + getRootDir()
+replace github.com/enthus-golang/gowsdl => ` + getRootDir()
 
 	err = os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goModContent), 0644)
 	require.NoError(t, err)

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hooklift/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/types"
 )
 
 func TestWSDLError(t *testing.T) {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -13,12 +13,12 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/hooklift/gowsdl/pkg/core"
-	"github.com/hooklift/gowsdl/pkg/generator/templates"
-	"github.com/hooklift/gowsdl/pkg/http"
-	"github.com/hooklift/gowsdl/pkg/parser"
-	"github.com/hooklift/gowsdl/pkg/types"
-	"github.com/hooklift/gowsdl/pkg/utils"
+	"github.com/enthus-golang/gowsdl/pkg/core"
+	"github.com/enthus-golang/gowsdl/pkg/generator/templates"
+	"github.com/enthus-golang/gowsdl/pkg/http"
+	"github.com/enthus-golang/gowsdl/pkg/parser"
+	"github.com/enthus-golang/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/utils"
 )
 
 // Generator handles WSDL code generation

--- a/pkg/generator/templates/header.go
+++ b/pkg/generator/templates/header.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"encoding/xml"
 	"time"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 
 	{{/*range .Imports*/}}
 		{{/*.*/}}

--- a/pkg/generator/templates/header_tmpl.go
+++ b/pkg/generator/templates/header_tmpl.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"encoding/xml"
 	"time"
-	"github.com/hooklift/gowsdl/soap"
+	"github.com/enthus-golang/gowsdl/soap"
 
 	{{/*range .Imports*/}}
 		{{/*.*/}}

--- a/pkg/generator/wsdl2_integration_test.go
+++ b/pkg/generator/wsdl2_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hooklift/gowsdl/pkg/parser"
+	"github.com/enthus-golang/gowsdl/pkg/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/generator/wsdl_parse_test.go
+++ b/pkg/generator/wsdl_parse_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hooklift/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/http/download_test.go
+++ b/pkg/http/download_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hooklift/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/http/downloader.go
+++ b/pkg/http/downloader.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hooklift/gowsdl/pkg/types"
+	"github.com/enthus-golang/gowsdl/pkg/types"
 )
 
 // HTTPConfig interface defines methods required by the downloader


### PR DESCRIPTION
## Summary
- Fixed module path declaration in go.mod from `github.com/hooklift/gowsdl` to `github.com/enthus-golang/gowsdl`
- Updated all internal imports across the codebase to use the new module path
- Ensures `go install github.com/enthus-golang/gowsdl/cmd/gowsdl@latest` works correctly

## Test plan
- [x] Updated go.mod module declaration
- [x] Replaced all imports using find/replace with `replace_all=true`
- [x] Ran `go mod tidy` to update dependencies
- [x] All tests pass with `go test -v -race ./...`
- [x] Module can now be installed without version constraints conflict

🤖 Generated with [Claude Code](https://claude.ai/code)