### PR TITLE
Fix: Complex types with sequences generate proper field structures

### DIFF
--- a/fixtures/complex_sequence_test.wsdl
+++ b/fixtures/complex_sequence_test.wsdl
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+                  targetNamespace="http://test.com/ws" 
+                  xmlns:tns="http://test.com/ws">
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://test.com/ws">
+      <!-- Test complex type with inline sequence -->
+      <xsd:complexType name="Person">
+        <xsd:sequence>
+          <xsd:element name="Name" type="xsd:string"/>
+          <xsd:element name="Age" type="xsd:int"/>
+          <!-- Element with inline complex type with sequence -->
+          <xsd:element name="Address">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="Street" type="xsd:string"/>
+                <xsd:element name="City" type="xsd:string"/>
+                <xsd:element name="ZipCode" type="xsd:string"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+          <!-- Another inline complex type -->
+          <xsd:element name="Contact">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="Phone" type="xsd:string"/>
+                <xsd:element name="Email" type="xsd:string"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:sequence>
+      </xsd:complexType>
+      
+      <xsd:element name="GetPersonRequest">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="PersonId" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      
+      <xsd:element name="GetPersonResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="Person" type="tns:Person"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="GetPersonRequest">
+    <wsdl:part name="parameters" element="tns:GetPersonRequest"/>
+  </wsdl:message>
+  
+  <wsdl:message name="GetPersonResponse">
+    <wsdl:part name="parameters" element="tns:GetPersonResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name="PersonService">
+    <wsdl:operation name="GetPerson">
+      <wsdl:input message="tns:GetPersonRequest"/>
+      <wsdl:output message="tns:GetPersonResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="PersonServiceSOAP" type="tns:PersonService">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetPerson">
+      <soap:operation soapAction="http://test.com/ws/GetPerson"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="PersonService">
+    <wsdl:port name="PersonServicePort" binding="tns:PersonServiceSOAP">
+      <soap:address location="http://localhost:8080/PersonService"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/pkg/generator/complex_type_test.go
+++ b/pkg/generator/complex_type_test.go
@@ -1,0 +1,86 @@
+package generator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplexTypeWithInlineSequence(t *testing.T) {
+	wsdlFile := "../../fixtures/complex_sequence_test.wsdl"
+	
+	gen, err := New(wsdlFile, WithPackage("testpkg"))
+	require.NoError(t, err)
+	
+	code, err := gen.Generate(nil)
+	require.NoError(t, err)
+	
+	// Get the generated code - concatenate all files
+	var codeStr string
+	for filename, content := range code {
+		t.Logf("Generated file: %s", filename)
+		codeStr += string(content) + "\n"
+	}
+	
+	// Check that Person type has Address field with inline struct
+	assert.Contains(t, codeStr, "type Person struct {")
+	assert.Contains(t, codeStr, "Address struct {")
+	
+	// Check that Address has the expected fields, not just Value
+	assert.Contains(t, codeStr, "Street string")
+	assert.Contains(t, codeStr, "City string")
+	assert.Contains(t, codeStr, "ZipCode string")
+	
+	// Check Contact field too
+	assert.Contains(t, codeStr, "Contact struct {")
+	assert.Contains(t, codeStr, "Phone string")
+	assert.Contains(t, codeStr, "Email string")
+	
+	// Should NOT contain Value string for these complex types
+	assert.NotContains(t, codeStr, "Address struct {\n\t\tValue string")
+	assert.NotContains(t, codeStr, "Contact struct {\n\t\tValue string")
+}
+
+func TestComplexTypeFromOriginalWSDL(t *testing.T) {
+	// Test with the original problematic WSDL
+	wsdlFile := "/mnt/c/Users/info/repo/api/assets/go_webservice_demo.wsdl"
+	
+	// Skip if file doesn't exist
+	if !fileExists(wsdlFile) {
+		t.Skip("Original WSDL file not found")
+	}
+	
+	gen, err := New(wsdlFile, WithPackage("godemo"))
+	require.NoError(t, err)
+	
+	code, err := gen.Generate(nil)
+	require.NoError(t, err)
+	
+	// Find the generated file
+	require.NotEmpty(t, code, "Generated code should not be empty")
+	
+	// Look for the types file which contains the struct definitions
+	var codeStr string
+	for filename, content := range code {
+		t.Logf("Generated file: %s (size: %d)", filename, len(content))
+		if filename == "types" || len(content) > len(codeStr) {
+			codeStr = string(content)
+		}
+	}
+	
+	require.NotEmpty(t, codeStr, "Should have generated code content")
+	
+	// Check that Abholadresse has proper fields
+	// First, just check if the generated code contains the expected fields
+	assert.Contains(t, codeStr, "Firmenname1 string", "Generated code should contain Firmenname1 field")
+	assert.NotContains(t, codeStr, `Abholadresse struct {
+		Value string`, "Abholadresse should not have just Value field")
+}
+
+func fileExists(path string) bool {
+	// Simple file existence check
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/pkg/generator/templates/types.go
+++ b/pkg/generator/templates/types.go
@@ -51,7 +51,7 @@ const TypesTemplate = `
 			{{end}}
 		{{else if .ComplexType}}
 			{{/* Handle inline complex types */}}
-			{{if .ComplexType.SimpleContent}}
+			{{if .ComplexType.SimpleContent.Extension.Base}}
 				{{/* Simple content with attributes - generate inline struct */}}
 				{{if eq .MaxOccurs "unbounded"}}
 					{{$memberName}} []struct {
@@ -70,8 +70,109 @@ const TypesTemplate = `
 						{{end}}
 					} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
 				{{end}}
+			{{else if or .ComplexType.Sequence .ComplexType.Choice .ComplexType.All}}
+				{{/* Complex type with sequence/choice/all - generate inline struct */}}
+				{{if eq .MaxOccurs "unbounded"}}
+					{{$memberName}} []struct {
+						{{range .ComplexType.Sequence}}
+							{{$seqMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$seqTypeName := .Type | removeNamespacePrefix}}
+								{{$seqMemberType := toGoType $seqTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$seqMemberName}} []{{$seqMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$seqMemberName}} {{$seqMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$seqMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.Choice}}
+							{{$choiceMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$choiceTypeName := .Type | removeNamespacePrefix}}
+								{{$choiceMemberType := toGoType $choiceTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$choiceMemberName}} []{{$choiceMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$choiceMemberName}} {{$choiceMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$choiceMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.All}}
+							{{$allMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$allTypeName := .Type | removeNamespacePrefix}}
+								{{$allMemberType := toGoType $allTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$allMemberName}} []{{$allMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$allMemberName}} {{$allMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$allMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.Attributes}}
+							{{$attrName := .Name | replaceReservedWords | makePublic}}
+							{{$attrName}} {{toGoType .Type false}} ` + "`" + `xml:"{{.Name}},attr,omitempty" json:"{{.Name}},omitempty"` + "`" + `
+						{{end}}
+					} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+				{{else}}
+					{{$memberName}} struct {
+						{{range .ComplexType.Sequence}}
+							{{$seqMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$seqTypeName := .Type | removeNamespacePrefix}}
+								{{$seqMemberType := toGoType $seqTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$seqMemberName}} []{{$seqMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$seqMemberName}} {{$seqMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$seqMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.Choice}}
+							{{$choiceMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$choiceTypeName := .Type | removeNamespacePrefix}}
+								{{$choiceMemberType := toGoType $choiceTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$choiceMemberName}} []{{$choiceMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$choiceMemberName}} {{$choiceMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$choiceMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.All}}
+							{{$allMemberName := .Name | replaceReservedWords | makePublic}}
+							{{if .Type}}
+								{{$allTypeName := .Type | removeNamespacePrefix}}
+								{{$allMemberType := toGoType $allTypeName .Nillable}}
+								{{if eq .MaxOccurs "unbounded"}}
+									{{$allMemberName}} []{{$allMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{else}}
+									{{$allMemberName}} {{$allMemberType}} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+								{{end}}
+							{{else}}
+								{{$allMemberName}} string ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+							{{end}}
+						{{end}}
+						{{range .ComplexType.Attributes}}
+							{{$attrName := .Name | replaceReservedWords | makePublic}}
+							{{$attrName}} {{toGoType .Type false}} ` + "`" + `xml:"{{.Name}},attr,omitempty" json:"{{.Name}},omitempty"` + "`" + `
+						{{end}}
+					} ` + "`" + `xml:"{{.Name}},omitempty" json:"{{.Name}},omitempty"` + "`" + `
+				{{end}}
 			{{else}}
-				{{/* Regular complex type */}}
+				{{/* Regular complex type without sequence - fallback to using element name as type */}}
 				{{$typeName := .Name}}
 				{{$memberType := toGoType $typeName .Nillable}}
 				{{if eq .MaxOccurs "unbounded"}}


### PR DESCRIPTION
## Summary
- Fixed incorrect code generation for complex types containing sequences
- Complex types were being generated as `struct { Value string }` instead of proper field structures
- Root cause was faulty template condition that treated empty SimpleContent structs as truthy

## Changes
1. **Fixed template condition** in `pkg/generator/templates/types.go`:
   - Changed from `{{if .ComplexType.SimpleContent}}` to `{{if .ComplexType.SimpleContent.Extension.Base}}`
   - This ensures we only generate SimpleContent when there's actual content

2. **Added support for all element types**:
   - Now properly handles Sequence, Choice, and All elements
   - Each generates appropriate field structures

3. **Added comprehensive test coverage**:
   - Unit test with custom WSDL to verify inline complex type generation
   - Integration test using the original problematic WSDL file
   - Tests verify that complex types generate proper fields, not just Value string

## Example Fix
Before this fix, a complex type like `Abholadresse` would generate:
```go
Abholadresse struct {
    Value string `xml:",chardata" json:"-,"`
} `xml:"Abholadresse,omitempty" json:"Abholadresse,omitempty"`
```

After this fix, it correctly generates:
```go
Abholadresse struct {
    Firmenname1 string `xml:"Firmenname1,omitempty" json:"Firmenname1,omitempty"`
    Firmenname2 string `xml:"Firmenname2,omitempty" json:"Firmenname2,omitempty"`
    Strasse1 string `xml:"Strasse1,omitempty" json:"Strasse1,omitempty"`
    // ... other fields
} `xml:"Abholadresse,omitempty" json:"Abholadresse,omitempty"`
```

## Test plan
- [x] Added unit test for complex type with inline sequence
- [x] Added integration test with original WSDL
- [x] All existing tests pass
- [x] Manually verified generated code compiles and has correct structure

🤖 Generated with [Claude Code](https://claude.ai/code)