### PR TITLE
chore: update badges and add Codecov integration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -136,3 +136,8 @@ jobs:
           name: master.breakdown
           path: master.breakdown
           if-no-files-found: error
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hooklift/gowsdl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GoDoc](https://godoc.org/github.com/enthus-golang/gowsdl?status.svg)](https://godoc.org/github.com/enthus-golang/gowsdl)
-[![Build Status](https://github.com/enthus-golang/gowsdl/workflows/Test/badge.svg)](https://github.com/enthus-golang/gowsdl/actions)
-[![codecov](https://codecov.io/gh/hooklift/gowsdl/branch/main/graph/badge.svg)](https://codecov.io/gh/hooklift/gowsdl)
+[![Build Status](https://github.com/enthus-golang/gowsdl/workflows/Go/badge.svg)](https://github.com/enthus-golang/gowsdl/actions)
+[![codecov](https://codecov.io/gh/enthus-golang/gowsdl/branch/main/graph/badge.svg)](https://codecov.io/gh/enthus-golang/gowsdl)
 [![Go Report Card](https://goreportcard.com/badge/github.com/enthus-golang/gowsdl)](https://goreportcard.com/report/github.com/enthus-golang/gowsdl)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 


### PR DESCRIPTION
This pull request introduces updates to the CI workflow and documentation for the project. The most notable changes include adding a step to upload coverage reports to Codecov in the CI pipeline and updating badges in the `README.md` to reflect the current state of the repository.

### CI Workflow Updates:
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR139-R143): Added a step to upload coverage reports to Codecov using the `codecov-action` GitHub Action. This ensures coverage data is automatically submitted after tests run, improving visibility into code quality.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R6): Updated the "Build Status" badge to point to the new "Go" workflow and corrected the "Codecov" badge URL to match the repository's current structure.