### PR TITLE
fix: implement SOAP action extraction for CallContext

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -623,12 +623,18 @@ func (g *Generator) findSOAPAction(operation, portType string) string {
 			bindingPortType = bindingPortType[idx+1:]
 		}
 		
-		// Compare with the port type name (need to handle case sensitivity and variations)
-		// Handle cases like: TestPortType == TestPort, TestPortType == TestPortType, etc.
-		if strings.EqualFold(bindingPortType, portType) || 
-		   strings.EqualFold(bindingPortType, portType+"Type") || 
-		   strings.EqualFold(bindingPortType, portType+"PortType") || 
-		   strings.EqualFold(bindingPortType+"PortType", portType) {
+		// Normalize names by removing common suffixes to provide a more robust comparison
+		normalizedBindingPortType := bindingPortType
+		normalizedBindingPortType = strings.TrimSuffix(normalizedBindingPortType, "PortType")
+		normalizedBindingPortType = strings.TrimSuffix(normalizedBindingPortType, "Port")
+		normalizedBindingPortType = strings.TrimSuffix(normalizedBindingPortType, "Type")
+		
+		normalizedPortType := portType
+		normalizedPortType = strings.TrimSuffix(normalizedPortType, "PortType")
+		normalizedPortType = strings.TrimSuffix(normalizedPortType, "Port")
+		normalizedPortType = strings.TrimSuffix(normalizedPortType, "Type")
+		
+		if strings.EqualFold(normalizedBindingPortType, normalizedPortType) {
 			// Find the operation in this binding
 			for _, op := range binding.Operations {
 				if op.Name == operation {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -611,7 +611,33 @@ func (g *Generator) findType(message string) string {
 }
 
 func (g *Generator) findSOAPAction(operation, portType string) string {
-	// TODO: Implement SOAP action finding logic
+	if g.wsdl == nil {
+		return ""
+	}
+
+	// Find the binding that references the port type
+	for _, binding := range g.wsdl.Binding {
+		// Check if this binding is for the port type we're looking for
+		bindingPortType := binding.Type
+		if idx := strings.LastIndex(bindingPortType, ":"); idx != -1 {
+			bindingPortType = bindingPortType[idx+1:]
+		}
+		
+		// Compare with the port type name (need to handle case sensitivity and variations)
+		// Handle cases like: TestPortType == TestPort, TestPortType == TestPortType, etc.
+		if strings.EqualFold(bindingPortType, portType) || 
+		   strings.EqualFold(bindingPortType, portType+"Type") || 
+		   strings.EqualFold(bindingPortType, portType+"PortType") || 
+		   strings.EqualFold(bindingPortType+"PortType", portType) {
+			// Find the operation in this binding
+			for _, op := range binding.Operations {
+				if op.Name == operation {
+					return op.SOAPOperation.SOAPAction
+				}
+			}
+		}
+	}
+	
 	return ""
 }
 

--- a/pkg/generator/soapaction_test.go
+++ b/pkg/generator/soapaction_test.go
@@ -193,6 +193,28 @@ func TestFindSOAPAction(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name:      "handles complex suffix variations",
+			operation: "TestOp",
+			portType:  "MyService",
+			wsdl: &parser.WSDL{
+				Binding: []*parser.WSDLBinding{
+					{
+						Name: "MyServiceBinding",
+						Type: "tns:MyServicePortType",
+						Operations: []*parser.WSDLOperation{
+							{
+								Name: "TestOp",
+								SOAPOperation: parser.WSDLSOAPOperation{
+									SOAPAction: "http://example.com/MyServiceTestOp",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "http://example.com/MyServiceTestOp",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/generator/soapaction_test.go
+++ b/pkg/generator/soapaction_test.go
@@ -1,0 +1,205 @@
+package generator
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/enthus-golang/gowsdl/pkg/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSOAPActionInGeneratedCode(t *testing.T) {
+	// Create a temporary WSDL file
+	wsdlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+                  targetNamespace="http://example.com/test" 
+                  xmlns:tns="http://example.com/test" 
+                  name="TestService">
+	
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://example.com/test">
+			<xsd:element name="TestRequest" type="xsd:string"/>
+			<xsd:element name="TestResponse" type="xsd:string"/>
+		</xsd:schema>
+	</wsdl:types>
+	
+	<wsdl:message name="TestRequestMessage">
+		<wsdl:part name="parameters" element="tns:TestRequest"/>
+	</wsdl:message>
+	
+	<wsdl:message name="TestResponseMessage">
+		<wsdl:part name="parameters" element="tns:TestResponse"/>
+	</wsdl:message>
+	
+	<wsdl:portType name="TestPortType">
+		<wsdl:operation name="TestOperation">
+			<wsdl:input message="tns:TestRequestMessage"/>
+			<wsdl:output message="tns:TestResponseMessage"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	
+	<wsdl:binding name="TestBinding" type="tns:TestPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="TestOperation">
+			<soap:operation soapAction="http://example.com/test/TestOperation"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	
+	<wsdl:service name="TestService">
+		<wsdl:port name="TestPort" binding="tns:TestBinding">
+			<soap:address location="http://example.com/test"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>`
+
+	// Write to temp file
+	tmpFile, err := os.CreateTemp("", "test-*.wsdl")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	_, err = tmpFile.WriteString(wsdlContent)
+	require.NoError(t, err)
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	// Create generator
+	gen, err := New(tmpFile.Name(), WithPackage("testpkg"))
+	require.NoError(t, err)
+
+	// Generate code
+	result, err := gen.Generate(context.Background())
+	require.NoError(t, err)
+
+	// Check that operations file contains SOAP action
+	operationsCode, ok := result["operations"]
+	require.True(t, ok, "operations file should be generated")
+
+	// Verify SOAP action is included in CallContext
+	assert.Contains(t, string(operationsCode), `CallContext(ctx, "http://example.com/test/TestOperation", request, response)`)
+}
+
+func TestFindSOAPAction(t *testing.T) {
+	tests := []struct {
+		name        string
+		operation   string
+		portType    string
+		wsdl        *parser.WSDL
+		expected    string
+	}{
+		{
+			name:      "finds soap action for matching operation",
+			operation: "TestOp",
+			portType:  "TestPortType",
+			wsdl: &parser.WSDL{
+				Binding: []*parser.WSDLBinding{
+					{
+						Name: "TestBinding",
+						Type: "tns:TestPortType",
+						Operations: []*parser.WSDLOperation{
+							{
+								Name: "TestOp",
+								SOAPOperation: parser.WSDLSOAPOperation{
+									SOAPAction: "http://example.com/TestOp",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "http://example.com/TestOp",
+		},
+		{
+			name:      "handles port type without suffix",
+			operation: "TestOp",
+			portType:  "TestPort",
+			wsdl: &parser.WSDL{
+				Binding: []*parser.WSDLBinding{
+					{
+						Name: "TestBinding",
+						Type: "tns:TestPortType",
+						Operations: []*parser.WSDLOperation{
+							{
+								Name: "TestOp",
+								SOAPOperation: parser.WSDLSOAPOperation{
+									SOAPAction: "http://example.com/TestOp",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "http://example.com/TestOp",
+		},
+		{
+			name:      "returns empty string when operation not found",
+			operation: "NonExistent",
+			portType:  "TestPortType",
+			wsdl: &parser.WSDL{
+				Binding: []*parser.WSDLBinding{
+					{
+						Name: "TestBinding",
+						Type: "tns:TestPortType",
+						Operations: []*parser.WSDLOperation{
+							{
+								Name: "TestOp",
+								SOAPOperation: parser.WSDLSOAPOperation{
+									SOAPAction: "http://example.com/TestOp",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:      "returns empty string when wsdl is nil",
+			operation: "TestOp",
+			portType:  "TestPortType",
+			wsdl:      nil,
+			expected:  "",
+		},
+		{
+			name:      "handles empty soap action",
+			operation: "TestOp",
+			portType:  "TestPortType",
+			wsdl: &parser.WSDL{
+				Binding: []*parser.WSDLBinding{
+					{
+						Name: "TestBinding",
+						Type: "tns:TestPortType",
+						Operations: []*parser.WSDLOperation{
+							{
+								Name: "TestOp",
+								SOAPOperation: parser.WSDLSOAPOperation{
+									SOAPAction: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gen := &Generator{wsdl: tt.wsdl}
+			result := gen.findSOAPAction(tt.operation, tt.portType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/generator/utils_test.go
+++ b/pkg/generator/utils_test.go
@@ -218,8 +218,8 @@ func TestGeneratorHelperMethods(t *testing.T) {
 
 	t.Run("findSOAPAction", func(t *testing.T) {
 		action := g.findSOAPAction("TestOperation", "TestPortType")
-		// Currently returns empty string as it's not implemented
-		assert.Equal(t, "", action)
+		// Should return the SOAP action from the WSDL binding
+		assert.Equal(t, "testAction", action)
 	})
 
 	t.Run("findType", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR implements the missing functionality to extract SOAP actions from WSDL bindings and include them in the generated `CallContext` calls. Previously, the second parameter was always an empty string, which meant SOAP actions defined in the WSDL were ignored.

### Problem
When running `go run cmd/gowsdl -o wsdl.go -p godemo /path/to/webservice.wsdl`, the generated code would ignore the `soapAction` attribute from the WSDL binding, resulting in:
```go
err := service.client.CallContext(ctx, "", request, response)
```

### Solution
- Implemented the `findSOAPAction` function that searches through WSDL bindings to find the correct SOAP action for each operation
- The function handles various naming conventions (e.g., `TestPort` vs `TestPortType`)
- Updated the generated code to properly include SOAP actions:
```go
err := service.client.CallContext(ctx, "https://wsdemo.ax4.com/ws/4020/GOMCL/SendungsDaten/", request, response)
```

### Changes
- Implemented `findSOAPAction` in `pkg/generator/generator.go`
- Added comprehensive tests in `pkg/generator/soapaction_test.go`
- Updated existing test expectations in `pkg/generator/utils_test.go`

### Testing
- Added unit tests for the `findSOAPAction` function covering various scenarios
- Added integration test to verify SOAP actions appear correctly in generated code
- All existing tests pass

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Run `golangci-lint run` - no issues
- [x] Test with real WSDL files to verify SOAP actions are correctly extracted
- [ ] Manual testing with various WSDL files

🤖 Generated with [Claude Code](https://claude.ai/code)